### PR TITLE
Fix Swift libraries detection for long paths with spaces

### DIFF
--- a/package_ipa.sh
+++ b/package_ipa.sh
@@ -34,7 +34,7 @@ if [ -d "${APP}/Frameworks" ];
 then
     mkdir -p "${TEMP_IPA_BUILT}/SwiftSupport"
 
-    for SWIFT_LIB in $(ls -1 ${APP}/Frameworks); do 
+    for SWIFT_LIB in $(ls -1 "${APP}/Frameworks/"); do
         echo "Copying ${SWIFT_LIB}"
         cp "${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos/${SWIFT_LIB}" "${TEMP_IPA_BUILT}/SwiftSupport"
     done


### PR DESCRIPTION
Just added quotes around `ls` statement.
